### PR TITLE
use public rules_jvm_external

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -13,13 +13,14 @@ rules_oss_audit_setup()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-RULES_JVM_EXTERNAL_COMMIT = "4fbe03fb18d6aca876b63b6f3de1b900ccf9c6a4"
+RULES_JVM_EXTERNAL_TAG = "4.2"
+RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca"
 
 http_archive(
     name = "rules_jvm_external",
-    sha256 = "cf243b1bf7d551f61059fe81ddee92fe389f60e0542907c29e26645639134bb5",
-    strip_prefix = "mirrors_github_rules_jvm_external-{0}-{0}".format(RULES_JVM_EXTERNAL_COMMIT),
-    url = "https://gitlab.eng.vmware.com/api/v4/projects/core-build%2Fmirrors_github_rules_jvm_external/repository/archive.zip?sha={}".format(RULES_JVM_EXTERNAL_COMMIT),
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
 http_archive(


### PR DESCRIPTION
Users outside of vmware are unable to access gitlab.eng.vmware.com.  This prevents the README example from building.  Let's use the public rules so `bazel build //examples:tar-oss-audit` can work in an OSS context.