### PR TITLE
[docs] Update docs referring setup() and dependencies() in workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,17 @@ To use `oss_audit` in your project, first add it to your `WORKSPACE` file:
 ```starlark
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-RULE_OSS_AUDIT_COMMIT = "3885863c6953668c6a696b908d138264b76e3d63"
+RULE_OSS_AUDIT_COMMIT = "5ae338712005a616c11d69a669d669e3742c1c83"
 
 http_archive(
     name = "rules_oss_audit",
-    sha256 = "87cd76d9e33a1e70fd99ab795b9e431a41feaeed8e96caaf7dba300fab804116",
+    sha256 = "cabb4d985eb9efe40326436e683a90e74603dd282ae2a0af2a21bf078f07cf1b",
     strip_prefix = "rules_oss_audit-%s" % RULE_OSS_AUDIT_COMMIT,
     url = "https://github.com/vmware/rules_oss_audit/archive/%s.zip" % RULE_OSS_AUDIT_COMMIT,
 )
+
+load("@rules_oss_audit//oss_audit:setup.bzl", "rules_oss_audit_setup")
+rules_oss_audit_setup()
 ```
 
 For basic usage, add the following code in your `BUILD` file:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ http_archive(
     url = "https://github.com/vmware/rules_oss_audit/archive/%s.zip" % RULE_OSS_AUDIT_COMMIT,
 )
 
+load("@rules_oss_audit//oss_audit:repositories.bzl", "rules_oss_audit_dependencies")
+rules_oss_audit_dependencies()
+
 load("@rules_oss_audit//oss_audit:setup.bzl", "rules_oss_audit_setup")
 rules_oss_audit_setup()
 ```


### PR DESCRIPTION
When I use the rules in a separate repo I get the following error:
```
ERROR: /home/luxe/Desktop/repos/bazel-buildfarm/BUILD:144:10: every rule of type oss_audit implicitly depends upon the target '@rules_oss_audit//oss_audit/tools:generate_boms', but this target could not be found because of: error loading package '@rules_oss_audit//oss_audit/tools': Unable to find package for @oss_audit_deps//:requirements.bzl: The repository '@oss_audit_deps' could not be resolved: Repository '@oss_audit_deps' is not defined.
Documentation for implicit attribute _generate_boms of rules of type oss_audit:
Generates the BOM and BOM-issues files and validates oss package usage
```

Maybe I'm missing something because I thought transitive workspaces were evaluated and therefore the requirements.bzl should have already been generated.  My workaround is to call `rules_oss_audit_setup()` in my own workspace.  That resolves the problem?  Should we tell users of this ruleset to do the same?