### PR TITLE
Aspect to handle implicit dependencies.

### DIFF
--- a/oss_audit/java/oss_audit.bzl
+++ b/oss_audit/java/oss_audit.bzl
@@ -5,6 +5,7 @@
 
 """
 
+
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
@@ -117,6 +118,7 @@ _collect_maven_bom = aspect(
     `maven_coordinates` information and use that to generate oss manifest file.
     """,
     implementation = _collect_maven_bom_impl,
+    apply_to_generating_rules = True,
 )
 
 def _oss_audit_impl(ctx):


### PR DESCRIPTION
Aspect to handle implicit dependencies by traversing the output file's generating rules.

Fixes #4 

Testing done:
Tested with `bazel-buildfarm` code change locally; diff below. The generated bom now contains 145 packages.

```
rtabassum@rtabassum-a01 bazel-buildfarm % git diff
diff --git a/BUILD b/BUILD
index 08122f82..5df1961e 100644
--- a/BUILD
+++ b/BUILD
@@ -143,8 +143,8 @@ java_image(
 
 oss_audit(
     name = "buildfarm-server-audit",
-    #src = "//src/main/java/build/buildfarm/rpms/server:buildfarm-server-rpm",
-    src = "//src/main/java/build/buildfarm/rpms/server:buildfarm-server-rpm2",
+    src = "//src/main/java/build/buildfarm/rpms/server:buildfarm-server-rpm",
+    #src = "//src/main/java/build/buildfarm/rpms/server:buildfarm-server-rpm2",
     #src = "//src/main/java/build/buildfarm:buildfarm-server_deploy.jar"
     #src = "//src/main/java/build/buildfarm:buildfarm-server"
 )
diff --git a/deps.bzl b/deps.bzl
index ba156a62..4058455a 100644
--- a/deps.bzl
+++ b/deps.bzl
@@ -108,9 +108,9 @@ def archive_dependencies(third_party):
         
         {
             "name": "rules_oss_audit",
-            "sha256": "cabb4d985eb9efe40326436e683a90e74603dd282ae2a0af2a21bf078f07cf1b",
-            "strip_prefix": "rules_oss_audit-5ae338712005a616c11d69a669d669e3742c1c83",
-            "url": "https://github.com/vmware/rules_oss_audit/archive/5ae338712005a616c11d69a669d669e3742c1c83.zip",
+            #"sha256": "cabb4d985eb9efe40326436e683a90e74603dd282ae2a0af2a21bf078f07cf1b",
+            "strip_prefix": "rules_oss_audit-c7aa9df46698717d2e2ad8b5316c177f2da26b92",
+            "url": "https://github.com/vmware/rules_oss_audit/archive/c7aa9df46698717d2e2ad8b5316c177f2da26b92.zip",
         },
```