### PR TITLE
Upgrade rules_python

### DIFF
--- a/oss_audit/repositories.bzl
+++ b/oss_audit/repositories.bzl
@@ -6,8 +6,8 @@ def rules_oss_audit_dependencies():
     # use maybe
     http_archive(
         name = "rules_python",
-        sha256 = "954aa89b491be4a083304a2cb838019c8b8c3720a7abb9c4cb81ac7a24230cea",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz",
+        sha256 = "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
This fixes a failure in downstream, that needs a newer version of rules_python, to support py_proto_library.

Addresses: https://github.com/bazelbuild/bazel/issues/17874